### PR TITLE
Do not open search engine on Esc

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,9 @@ const registerLaunch = (extension: string, path: string) => {
 		const search = await vscode.window.showInputBox({
 			placeHolder: 'Search',
 		});
-		launchSearch(path, search || "");
+		if (typeof search === "string") {
+			launchSearch(path, search);
+		}
 	});
 	return disposable;
 };


### PR DESCRIPTION
Fixes #44 

Context: `node_modules/@types/vscode/index.d.ts` line 7828

```ts
/**
 * Opens an input box to ask the user for input.
 *
 * The returned value will be `undefined` if the input box was canceled (e.g. pressing ESC). Otherwise the
 * returned value will be the string typed by the user or an empty string if the user did not type
 * anything but dismissed the input box with OK.
 *
 * @param options Configures the behavior of the input box.
 * @param token A token that can be used to signal cancellation.
 * @return A promise that resolves to a string the user provided or to `undefined` in case of dismissal.
 */
export function showInputBox(options?: InputBoxOptions, token?: CancellationToken): Thenable<string | undefined>;

```